### PR TITLE
Refactor Keycloak token logic to accept dynamic minValidity

### DIFF
--- a/src/components/organizations/CreateOrganizationForm.vue
+++ b/src/components/organizations/CreateOrganizationForm.vue
@@ -40,6 +40,7 @@ import { reset } from "@formkit/core";
 import { useOrganizationsStore } from "../../stores/organizations";
 import { useIndexStore } from "../../stores";
 import { useRouter } from "vue-router";
+import keycloakIns, { updateKeycloakToken } from "../../lib/keycloak";
 
 const router = useRouter();
 
@@ -58,7 +59,8 @@ const create = async (fields: {
   const responseData = await organizationStore.createOrganization({
     name: fields.stepper.generalInfo.name,
   });
-  new Promise((resolve) => setTimeout(resolve, 250));
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  await updateKeycloakToken(keycloakIns, 1000);
   submitted.value = true;
   reset("createOrganizationForm");
   await organizationStore.fetchOrganizations();

--- a/src/lib/keycloak.ts
+++ b/src/lib/keycloak.ts
@@ -38,12 +38,15 @@ export const initializeKeycloak = async (keycloak: Keycloak) => {
     // await authStore.login();
   }
 
-  setInterval(() => updateKeycloakToken(keycloak), 60000);
+  setInterval(() => updateKeycloakToken(keycloak, 70), 60000);
   return keycloak;
 };
 
-export const updateKeycloakToken = async (keycloak: Keycloak) => {
-  const isRefreshed = await keycloak.updateToken(70);
+export const updateKeycloakToken = async (
+  keycloak: Keycloak,
+  minValidity: number,
+) => {
+  const isRefreshed = await keycloak.updateToken(minValidity);
   if (isRefreshed && keycloak.token) {
     setAxiosAuthHeader(keycloak.token);
     apiClient.setApiKey(keycloak.token);


### PR DESCRIPTION
Updated `updateKeycloakToken` to take a `minValidity` parameter and adjusted its usage across the application. This ensures greater flexibility for token refresh intervals and improves token management consistency.