### PR TITLE
Handle unsupported node types gracefully in DataFieldForm

### DIFF
--- a/src/components/product-data-model-drafts/DataFieldForm.vue
+++ b/src/components/product-data-model-drafts/DataFieldForm.vue
@@ -79,7 +79,9 @@ const formSchemaFromType = (type: string) => {
       ];
 
     default:
-      console.warn(`Unsupported node type: ${type}, using generic form`);
+      console.warn(
+        `[DataFieldForm] Unsupported node type: ${type}, using generic form. Please implement a form schema for this type.`,
+      );
       return [];
   }
 };

--- a/src/components/product-data-model-drafts/DataFieldForm.vue
+++ b/src/components/product-data-model-drafts/DataFieldForm.vue
@@ -79,7 +79,8 @@ const formSchemaFromType = (type: string) => {
       ];
 
     default:
-      throw new Error(`Unsupported node type: ${type}`);
+      console.warn(`Unsupported node type: ${type}, using generic form`);
+      return [];
   }
 };
 


### PR DESCRIPTION
### Description

This update modifies the `DataFieldForm` behavior to handle unsupported node types more gracefully. Instead of throwing an error, a warning is logged, and an empty array is returned as a fallback. This change ensures the application remains stable and prevents runtime crashes.

### Related Issues

* No related issues were linked to this pull request.

### Checklist

- [ ] Tests added for new functionality.
- [ ] Documentation updated where applicable.
- [ ] Code reviewed for best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form handling by preventing errors when encountering unsupported field types. The form now displays a generic fallback instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->