### PR TITLE
remove unused env-templates directory

### DIFF
--- a/env-templates/.env
+++ b/env-templates/.env
@@ -1,5 +1,0 @@
-VITE_ADMIN_ROOT=http://localhost:5173
-VITE_API_ROOT=http://api.open-dpp.localhost:20080
-#VITE_API_ROOT=http://localhost:3000 # if api also runs locally in watch mode
-VITE_KEYCLOAK_ROOT=http://auth.open-dpp.localhost:20080
-VITE_VIEW_ROOT_URL=http://view.open-dpp.localhost:20080"


### PR DESCRIPTION
The env-templates directory is superseded by the .env.examples and must be deleted to avoid confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the environment configuration template by removing outdated variables to align with the current setup.
  * Reduces noise in local configuration, minimizing setup errors and confusion across environments.
  * Simplifies developer onboarding by clarifying which variables are actually required.
  * No user-facing changes; build and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->